### PR TITLE
feat: 회원 추가 정보 입력 기능 구현

### DIFF
--- a/src/main/java/com/itcen/censquare/domain/member/controller/MemberController.java
+++ b/src/main/java/com/itcen/censquare/domain/member/controller/MemberController.java
@@ -3,20 +3,24 @@ package com.itcen.censquare.domain.member.controller;
 import com.itcen.censquare.domain.auth.AuthConstants;
 import com.itcen.censquare.domain.auth.oauth.CustomUserDetails;
 import com.itcen.censquare.domain.auth.util.CookieUtil;
+import com.itcen.censquare.domain.member.dto.MemberExtraReqDto;
 import com.itcen.censquare.domain.member.dto.MemberRespDto;
 import com.itcen.censquare.domain.member.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -55,4 +59,11 @@ public class MemberController {
     return ResponseEntity.ok(memberService.getMyInfo(userDetails.getMember()));
   }
 
+  @PostMapping("/signup-extra")
+  public ResponseEntity<Void> signupExtraInfo(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestBody @Valid MemberExtraReqDto memberExtraReqDto) {
+    memberService.saveExtraInfo(userDetails.getMember(), memberExtraReqDto);
+    return ResponseEntity.status(HttpStatus.OK).build();
+  }
 }

--- a/src/main/java/com/itcen/censquare/domain/member/dto/MemberExtraReqDto.java
+++ b/src/main/java/com/itcen/censquare/domain/member/dto/MemberExtraReqDto.java
@@ -1,0 +1,28 @@
+package com.itcen.censquare.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberExtraReqDto {
+
+  @NotNull(message = "기수는 필수 항목입니다.")
+  private Long batchNumber;
+
+  @NotBlank(message = "닉네임을 입력해주세요.")
+  @Size(max = 50, message = "닉네임은 50자 이내여야 합니다.")
+  private String nickname;
+
+  @NotBlank(message = "이름을 입력해주세요.")
+  @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
+  private String name;
+
+}

--- a/src/main/java/com/itcen/censquare/domain/member/entity/Member.java
+++ b/src/main/java/com/itcen/censquare/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.itcen.censquare.domain.member.entity;
 
 import com.itcen.censquare.domain.member.entity.enums.Provider;
 import com.itcen.censquare.domain.member.entity.enums.Role;
+import com.itcen.censquare.domain.member.entity.enums.State;
 import com.itcen.censquare.global.entity.TimeStampedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,13 +43,25 @@ public class Member extends TimeStampedEntity {
 
   private Long batchNumber;
 
-  //  @Column(nullable = false, length = 50)
+  @Column(length = 50)
   private String nickname;
 
-  //  @Column(nullable = false, length = 50)
+  @Column(length = 50)
   private String name;
 
   @Column(nullable = false, length = 50)
   private String email;
 
+  @Enumerated(EnumType.STRING)
+  private State state;
+
+  public void updateExtraInfo(Long batchNumber, String nickname, String name) {
+    this.batchNumber = batchNumber;
+    this.nickname = nickname;
+    this.name = name;
+  }
+
+  public void changeState(State newState) {
+    this.state = newState;
+  }
 }

--- a/src/main/java/com/itcen/censquare/domain/member/entity/enums/State.java
+++ b/src/main/java/com/itcen/censquare/domain/member/entity/enums/State.java
@@ -1,0 +1,6 @@
+package com.itcen.censquare.domain.member.entity.enums;
+
+public enum State {
+  NEEDS_MORE_INFO,
+  COMPLETED,
+}

--- a/src/main/java/com/itcen/censquare/domain/member/service/MemberService.java
+++ b/src/main/java/com/itcen/censquare/domain/member/service/MemberService.java
@@ -1,18 +1,33 @@
 package com.itcen.censquare.domain.member.service;
 
+import com.itcen.censquare.domain.member.dto.MemberExtraReqDto;
 import com.itcen.censquare.domain.member.dto.MemberRespDto;
 import com.itcen.censquare.domain.member.entity.Member;
+import com.itcen.censquare.domain.member.entity.enums.State;
 import com.itcen.censquare.domain.member.mapper.MemberMapper;
+import com.itcen.censquare.domain.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemberService {
 
+  public static final String ERROR_NOT_FOUND_MEMBER = "Member 찾을 수 없음 ";
   private final MemberMapper memberMapper;
+  private final MemberRepository memberRepository;
 
   public MemberRespDto getMyInfo(Member member) {
     return memberMapper.toDto(member);
+  }
+
+  public void saveExtraInfo(Member member, MemberExtraReqDto memberExtraReqDto) {
+    Member foundMember = memberRepository.findById(member.getMemberId())
+        .orElseThrow(() -> new IllegalArgumentException(ERROR_NOT_FOUND_MEMBER));
+    foundMember.updateExtraInfo(memberExtraReqDto.getBatchNumber(), memberExtraReqDto.getNickname(),
+        memberExtraReqDto.getName());
+    foundMember.changeState(State.COMPLETED);
   }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #16 

✨소셜 로그인만으로는 수집되지 않는 회원 정보(이름, 닉네임, 기수)를 입력받기 위한 기능을 구현했습니다.  

OAuth로그인 직후 회원 상태(State)가 `NEEDS_MORE_INFO`로 저장되며,  `NEEDS_MORE_INFO`인 경우, 추가 입력 화면으로 리디렉션되며, 사용자로부터 정보를 받아 저장할 수 있도록 API를 추가했습니다.  

이 정보는 추후 멤버십 구분, 조직 기반 기능, 사용자 경험 최적화 등에 사용되며,  
데이터의 일관성을 확보하고 불완전한 회원 상태를 방지하기 위해 도입되었습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
